### PR TITLE
Fix comment wording

### DIFF
--- a/include/visibility_graph.h
+++ b/include/visibility_graph.h
@@ -64,8 +64,8 @@ class VisibilityGraph : public GraphBase<NodeProperty, EdgeProperty> {
              const Point_2& goal, const Polygon_2& goal_visibility_polygon,
              std::vector<Point_2>* waypoints) const;
 
-  // Convenience function: addtionally adds original start and goal to shortest
-  // path, if they were outside of polygon.
+  // Convenience function: additionally inserts the original start and goal into
+  // the shortest path when they lie outside the polygon.
   bool solveWithOutsideStartAndGoal(const Point_2& start, const Point_2& goal,
                                     std::vector<Point_2>* waypoints) const;
   // Given a solution, get the concatenated 2D waypoints.


### PR DESCRIPTION
## Summary
- correct minor typo in convenience function comment

## Testing
- `cmake .. && make -j$(nproc)` *(fails: Could not find a package configuration file provided by "Eigen3")*

------
https://chatgpt.com/codex/tasks/task_e_68403315cf00832ebcbe4e5a584192c1