### PR TITLE
Fix getEdgeProperty implementation

### DIFF
--- a/include/graph_base_impl.h
+++ b/include/graph_base_impl.h
@@ -137,8 +137,7 @@ const NodeProperty* GraphBase<NodeProperty, EdgeProperty>::getNodeProperty(
 }
 
 template <class NodeProperty, class EdgeProperty>
-const EdgeProperty*
-GraphBase<NodeProperty, EdgeProperty>::GraphBase::getEdgeProperty(
+const EdgeProperty* GraphBase<NodeProperty, EdgeProperty>::getEdgeProperty(
     const EdgeId& edge_id) const {
   if (edgePropertyExists(edge_id)) {
     return &(edge_properties_.at(edge_id));


### PR DESCRIPTION
## Summary
- remove an erroneous `GraphBase::` qualifier from `getEdgeProperty`

## Testing
- `cmake ..` *(fails: could not find Eigen3)*

------
https://chatgpt.com/codex/tasks/task_e_684033139fec832eaa02ebcd43a3bff7