### PR TITLE
Fix typo in visibility graph comment

### DIFF
--- a/include/visibility_graph.h
+++ b/include/visibility_graph.h
@@ -34,7 +34,7 @@ struct NodeProperty {
   NodeProperty(const Point_2& coordinates, const Polygon_2& visibility)
       : coordinates(coordinates), visibility(visibility) {}
   Point_2 coordinates;   // The 2D coordinates.
-  Polygon_2 visibility;  // The visibile polygon from the vertex.
+  Polygon_2 visibility;  // The visible polygon from the vertex.
 };
 
 struct EdgeProperty {};


### PR DESCRIPTION
## Summary
- fix a minor spelling error in `NodeProperty` comment of `visibility_graph.h`

## Testing
- `cmake -S . -B build` *(fails: could not find Eigen3)*
- `cmake --build build` *(fails: No rule to make target 'Makefile')*

------
https://chatgpt.com/codex/tasks/task_e_684033101978832eb194994205c087db