### PR TITLE
Add Google Test with sample GraphBase test

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,3 +28,6 @@ target_link_libraries(CoveragePlanner
         CGAL::CGAL_Core
         )
 
+enable_testing()
+add_subdirectory(tests)
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,19 @@
+include(FetchContent)
+
+FetchContent_Declare(
+  googletest
+  URL https://github.com/google/googletest/archive/refs/tags/release-1.12.1.zip
+)
+
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(googletest)
+
+add_executable(graph_base_test test_graph_base.cpp)
+
+target_include_directories(graph_base_test PRIVATE ${PROJECT_SOURCE_DIR}/include)
+
+target_link_libraries(graph_base_test gtest_main)
+
+add_test(NAME graph_base_test COMMAND graph_base_test)

--- a/tests/test_graph_base.cpp
+++ b/tests/test_graph_base.cpp
@@ -1,0 +1,28 @@
+#include <gtest/gtest.h>
+#include "graph_base.h"
+
+using namespace polygon_coverage_planning;
+
+class SimpleGraph : public GraphBase<int, int> {
+ public:
+  bool addEdges() override { return true; }
+  bool create() override { return true; }
+  bool addEdgePublic(const EdgeId& id, const int& prop, double cost) {
+    return addEdge(id, prop, cost);
+  }
+};
+
+TEST(GraphBaseTest, GetEdgeProperty) {
+  SimpleGraph g;
+  EXPECT_TRUE(g.addNode(1));
+  EXPECT_TRUE(g.addNode(2));
+  EXPECT_TRUE(g.addEdgePublic({0,1}, 42, 1.0));
+  const int* prop = g.getEdgeProperty({0,1});
+  ASSERT_NE(prop, nullptr);
+  EXPECT_EQ(*prop, 42);
+}
+
+int main(int argc, char **argv) {
+  ::testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
## Summary
- enable Google Test in CMake
- add a basic unit test for GraphBase edge properties

## Testing
- `cmake ..`
- `cmake --build .`
- `ctest --output-on-failure`

------
https://chatgpt.com/codex/tasks/task_e_684033164804832eb52e27cbc75988fe