### PR TITLE
Update dependencies for modern library versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,28 +1,27 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 project(CoveragePlanner)
 
 set(CMAKE_CXX_STANDARD 14)
 set(CMAKE_BUILD_TYPE Release)
 
-find_package(Eigen3 REQUIRED)
-find_package(OpenCV 4 REQUIRED)
-find_package(CGAL QUIET COMPONENTS Core)
+find_package(Eigen3 3.3 REQUIRED NO_MODULE)
+find_package(OpenCV 4 REQUIRED COMPONENTS core imgproc highgui)
+find_package(CGAL REQUIRED COMPONENTS Core)
 
-include_directories(${EIGEN_INCLUDE_DIRS})
-include_directories(${OpenCV_INCLUDE_DIRS})
-include_directories(${CGAL_INCLUDE_DIRS})
+
 
 file(GLOB_RECURSE srcs "src/*.cc" "src/*.cpp")
 file(GLOB_RECURSE hdrs "include/*.h")
 
+
 message("find source files: ${srcs}")
 message("find headers: ${hdrs}")
 
-include_directories(include)
-
 add_executable(CoveragePlanner ${srcs} ${hdrs})
 
-target_link_libraries(CoveragePlanner
+target_include_directories(CoveragePlanner PRIVATE include)
+target_link_libraries(CoveragePlanner PRIVATE
+        Eigen3::Eigen
         ${OpenCV_LIBS}
         CGAL::CGAL
         CGAL::CGAL_Core

--- a/include/coverage_planner.h
+++ b/include/coverage_planner.h
@@ -9,9 +9,9 @@
 #include <iostream>
 #include <math.h>
 
-#include "opencv2/core/core.hpp"
-#include "opencv2/highgui/highgui.hpp"
-#include "opencv2/imgproc/imgproc.hpp"
+#include <opencv2/core.hpp>
+#include <opencv2/highgui.hpp>
+#include <opencv2/imgproc.hpp>
 
 #include <CGAL/Boolean_set_operations_2.h>
 #include <CGAL/Surface_sweep_2_algorithms.h>


### PR DESCRIPTION
## Summary
- update OpenCV includes
- modernize CMake to use imported targets and require newer package versions

## Testing
- `cmake ..`
- `make -j4`
- `ctest --output-on-failure`


------
https://chatgpt.com/codex/tasks/task_e_6841962e0930832e840b4ed61d38c813